### PR TITLE
fix: strip dashed alias for camel case options

### DIFF
--- a/src/kolibri-cli.ts
+++ b/src/kolibri-cli.ts
@@ -50,7 +50,7 @@ export class KolibriCli extends Program {
     private loggedIn: boolean = false;
 
     constructor(private readonly environment: Environment) {
-        super({ help: true });
+        super({ help: true, parserConfiguration: { 'strip-dashed': true } });
 
         this.addKolibriCommands();
         this.on('run', (cmd: string | readonly string[]) => {
@@ -387,6 +387,7 @@ export class KolibriCli extends Program {
             return this.read(args);
         }));
         this.add(new SubscribeCommand().action(async (args: any) => {
+            console.log(args);
             return this.subscribe(args);
         }));
         this.add(new UnsubscribeCommand().action(async (args: any) => {

--- a/src/kolibri-cli.ts
+++ b/src/kolibri-cli.ts
@@ -387,7 +387,6 @@ export class KolibriCli extends Program {
             return this.read(args);
         }));
         this.add(new SubscribeCommand().action(async (args: any) => {
-            console.log(args);
             return this.subscribe(args);
         }));
         this.add(new UnsubscribeCommand().action(async (args: any) => {


### PR DESCRIPTION
Adds a configuration to remove dashed option alias if a camel case option is provided.